### PR TITLE
Fix broken documentation links and missing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,6 @@ In Bash run `source activate py-loop`, or in the Anaconda Prompt
 run `conda activate py-loop` to start the environment.
 
 Run `deactivate` to stop the environment.
+
+### To create the PyLoopKit package
+If you want to install a version of the PyLoopKit package based on the PyLoopKit on your local machine, run `python3 setup.py install` to call the setup script and install the package. You'll likely want to do this within the `py-loop` environment.

--- a/README.md
+++ b/README.md
@@ -23,4 +23,7 @@ run `conda activate py-loop` to start the environment.
 Run `deactivate` to stop the environment.
 
 ### To create the PyLoopKit package
-If you want to install a version of the PyLoopKit package based on the PyLoopKit on your local machine, run `python3 setup.py install` to call the setup script and install the package. You'll likely want to do this within the `py-loop` environment.
+If you want to install a version of the PyLoopKit package based on the PyLoopKit on your local machine, run `python3 setup.py install` within your PyLoopKit repo to call the setup script and install the package. You'll likely want to do this within the `py-loop` environment.
+
+### Running the unittests
+To run PyLoopKit's unit tests, run `python3 -m unittest discover` within your PyLoopKit repo

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A set of Python tools for building closed-loop insulin delivery apps (Python por
 ### To recreate the Virtual Environment
 1. This environment was developed with Anaconda. You'll need to install [Miniconda](https://conda.io/miniconda.html) or [Anaconda](https://anaconda-installer.readthedocs.io/en/latest/) for your platform.
 2. In a terminal, navigate to the directory where the environment.yml 
-is located (likely the PyLoopKit folder).
+is located (likely in PyLoopKit/pyloopkit folder).
 3. Run `conda env create`; this will download all of the package dependencies
 and install them in a virtual environment named py-loop. PLEASE NOTE: this
 may take up to 30 minutes to complete.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # PyLoopKit
 A set of Python tools for building closed-loop insulin delivery apps (Python port of LoopKit)
 
-<a href="/example_files/example_prediction_figure.png"><img src="/example_files/example_prediction_figure.png?raw=true" alt="Sample Prediction Figure from PyLoopKit"></a>
-
 [Link to Tidepool Loop repository version used for algorithm](https://github.com/tidepool-org/Loop/tree/8c1dfdba38fbf6588b07cee995a8b28fcf80ef69)
 
 [Link of Tidepool LoopKit repository version used for algorithm](https://github.com/tidepool-org/LoopKit/tree/57a9f2ba65ae3765ef7baafe66b883e654e08391)
 
 # To use this project
-## Please review [the documentation](docs/pyloopkit_documentation.md) for usage instructions, input data requirements, and other important details.
+## Please review [the documentation](pyloopkit/docs/pyloopkit_documentation.md) for usage instructions, input data requirements, and other important details.
 
 ### To recreate the Virtual Environment
 1. This environment was developed with Anaconda. You'll need to install [Miniconda](https://conda.io/miniconda.html) or [Anaconda](https://anaconda-installer.readthedocs.io/en/latest/) for your platform.

--- a/pyloopkit/docs/pyloopkit_documentation.md
+++ b/pyloopkit/docs/pyloopkit_documentation.md
@@ -291,7 +291,7 @@ _Installing the Virtual Environment_
 
 
 1. The PyLoopKit environment was developed with Anaconda. You'll need to install [Miniconda](https://conda.io/miniconda.html) or [Anaconda](https://anaconda-installer.readthedocs.io/en/latest/) for your platform.
-2. In a terminal, navigate to the directory where the environment.yml is located (likely the PyLoopKit folder).
+2. In a terminal, navigate to the directory where the environment.yml is located (likely the PyLoopKit/pyloopkit folder).
 3. Run `conda env create`; this will download all of the package dependencies and install them in a virtual environment named py-loop. PLEASE NOTE: this may take up to 30 minutes to complete.
 
 _Using the Virtual Environment_

--- a/pyloopkit/docs/pyloopkit_documentation.md
+++ b/pyloopkit/docs/pyloopkit_documentation.md
@@ -2,8 +2,6 @@
 
 Welcome to the documentation for PyLoopKit. This document contains instructions to help get you oriented to the project, and includes details on running the Loop Algorithm in Python. The project was started by Anna Quinlan in the summer of 2019; if you have any questions please reach out to [Ed Nykaza](mailto:ed@tidepool.org).
 
-<a href="/docs/prediction.png"><img src="/docs/prediction.png?raw=true" alt="Sample Prediction Figure from PyLoopKit"></a>
-
 # Important Notes
 
 

--- a/pyloopkit/environment.yml
+++ b/pyloopkit/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - pylint=2.3.1
   - python==3.7.3
   - pip:
+    - backports-datetime-fromisoformat==1.0.0
     - tensorflow==2.0.0-beta1
     - numpy==1.16.4
     - pandas==0.24.2


### PR DESCRIPTION
A few of the links (including to the documentation) are broken and there is a missing dependency in the environment file (`backports-datetime-fromisoformat`); this PR fixes them